### PR TITLE
Fix Validation Cloud start date to June 2026

### DIFF
--- a/personal-site/src/lib/site.ts
+++ b/personal-site/src/lib/site.ts
@@ -101,7 +101,7 @@ export const workRoles: WorkRole[] = [
     company: 'Validation Cloud',
     title: 'Senior DevOps Engineer',
     initial: 'V',
-    start: { label: 'Sep 2025', dateTime: '2025-09-01' },
+    start: { label: 'Jun 2026', dateTime: '2026-06-01' },
     end: { label: 'Present', dateTime: '2026-08-06' },
   },
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Corrects the Validation Cloud experience start date from an invented **Sep 2025** to **Jun 2026**.

When adding the VC role in the site copy refresh, the start was inferred as the month after Phantom ended. That was wrong — VC started in June 2026.

Phantom (`Jul 2024 – Aug 2025`) and older roles are unchanged.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fd541-cee9-7fd0-80a2-568f12527b4e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fd541-cee9-7fd0-80a2-568f12527b4e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

